### PR TITLE
allow custom finder

### DIFF
--- a/src/Controller/Component/DataTablesComponent.php
+++ b/src/Controller/Component/DataTablesComponent.php
@@ -84,10 +84,11 @@ class DataTablesComponent extends Component
      * Find data
      *
      * @param $tableName
+     * @param $finder
      * @param array $options
      * @return array|\Cake\ORM\Query
      */
-    public function find($tableName, array $options = [])
+    public function find($tableName, $finder = 'all', array $options = [])
     {
 
         // -- get table object
@@ -96,7 +97,7 @@ class DataTablesComponent extends Component
 
         // -- get query options
         $this->_processRequest();
-        $data = $table->find('all', $options);
+        $data = $table->find($finder, $options);
 
         // -- record count
         $this->_viewVars['recordsTotal'] = $data->count();


### PR DESCRIPTION
Allow to use a custom finder in search.

Using this one can couple DataTablesComponent with SearchBeavior from https://github.com/FriendsOfCake/search/. Example code:

``` php
$foo = $this->request->query['search'];
$options = array_merge($this->Users->filterParams($foo), $options);
$data = $this->DataTables->find('Users', 'search', $options);
```

Apart from that, employing custom finders is good practice in cakephp3.
