### PR TITLE
Security: Use bound parameters

### DIFF
--- a/src/Controller/Component/DataTablesComponent.php
+++ b/src/Controller/Component/DataTablesComponent.php
@@ -141,20 +141,14 @@ class DataTablesComponent extends Component
 
     private function _addCondition($column, $value)
     {
-        $conditions = [];
-        $matching = [];
+        $condition = ["$column LIKE" => "$value%"];
 
         list($association, $field) = explode('.', $column);
-
         if( $this->_tableName == $association) {
-            $conditions[] = $column . ' LIKE "' . $value . '%"';
+            $this->config('conditions', $condition); // merges
         } else {
-            $matching[$association][] = $column . ' LIKE "' . $value . '%"';
+            $this->config('matching', [$association => $condition]); // merges
         }
-
-        $this->config('conditions', $conditions);
-        $this->config('matching', $matching);
-
     }
 
 }


### PR DESCRIPTION
Fixes how condition is expressed to the query builder. Also cleans up the _addCondition() method.
