### PR TITLE
return javascript code instead of echo

### DIFF
--- a/src/View/Helper/DataTablesHelper.php
+++ b/src/View/Helper/DataTablesHelper.php
@@ -56,7 +56,7 @@ class DataTablesHelper extends Helper
 
     public function draw($selector)
     {
-        echo sprintf('delay=%d;table=jQuery("%s").dataTable(%s);initSearch();', $this->config('delay'), $selector, json_encode($this->config()) );
+        return sprintf('delay=%d;table=jQuery("%s").dataTable(%s);initSearch();', $this->config('delay'), $selector, json_encode($this->config()) );
     }
 
 }


### PR DESCRIPTION
Return the javascript code instead of printing out right away. Makes the use more flexible, e.g.

``` php
$this->append('script', $this->domReady($dt->draw('#usersTable')));
```

Where `script` is a block that is printed at the end of the body in layout (and contains jquery, etc.).
