### PR TITLE
Table-wide search functionality

### DIFF
--- a/src/Controller/Component/DataTablesComponent.php
+++ b/src/Controller/Component/DataTablesComponent.php
@@ -141,20 +141,14 @@ class DataTablesComponent extends Component
 
     private function _addCondition($column, $value)
     {
-        $conditions = [];
-        $matching = [];
+        $condition = ["$column LIKE" => "$value%"];
 
         list($association, $field) = explode('.', $column);
-
         if( $this->_tableName == $association) {
-            $conditions[] = $column . ' LIKE "' . $value . '%"';
+            $this->config('conditions', $condition); // merges
         } else {
-            $matching[$association][] = $column . ' LIKE "' . $value . '%"';
+            $this->config('matching', [$association => $condition]); // merges
         }
-
-        $this->config('conditions', $conditions);
-        $this->config('matching', $matching);
-
     }
 
 }


### PR DESCRIPTION
Support datatable's global search alongside column searches. E.g. using:

``` php
'dom' => '<<"row"<"col-sm-4"i><"col-sm-8">f>rt>',
```

Performs the search on fields marked as searchable (default) in accordance with DataTables documentation.
