### PR TITLE
More flexibility esp. in javascript

### DIFF
--- a/src/View/Helper/DataTablesHelper.php
+++ b/src/View/Helper/DataTablesHelper.php
@@ -17,9 +17,6 @@ class DataTablesHelper extends Helper
     use StringTemplateTrait;
 
     protected $_defaultConfig = [
-        'ajax' => [
-            'dataSrc' => 'data'
-        ],
         'searching' => true,
         'processing' => true,
         'serverSide' => true,

--- a/src/View/Helper/DataTablesHelper.php
+++ b/src/View/Helper/DataTablesHelper.php
@@ -22,13 +22,22 @@ class DataTablesHelper extends Helper
         'serverSide' => true,
         'deferRender' => true,
         'dom' => '<<"row"<"col-sm-4"i><"col-sm-8"lp>>rt>',
-        'delay' => 600
+        'js' => [
+            'calls' => null,
+            'delay' => 600,
+        ],
     ];
 
     public function init(array $options = [])
     {
         $this->_templater = $this->templater();
         $this->config($options);
+
+        // -- default to initColumnSearch() if user didn't specify js calls array
+        if(is_null($this->config('js.calls')))
+        {
+            $this->config('js.calls', ['initColumnSearch']);
+        }
 
         // -- load i18n
         $this->config('language', [
@@ -53,7 +62,18 @@ class DataTablesHelper extends Helper
 
     public function draw($selector)
     {
-        echo sprintf('delay=%d;table=jQuery("%s").dataTable(%s);initSearch();', $this->config('delay'), $selector, json_encode($this->config()) );
+        // -- pass on parameters to javascript
+        $json = json_encode($this->config('js'));
+        $js = "params = $json;";
+
+        // -- initialize DataTables
+        $json = json_encode($this->config());
+        $js .= "table=jQuery('$selector').dataTable($json);";
+
+        // -- call javascript methods
+        $js .= implode('();', $this->config('js.calls')).'();';
+
+        echo $js;
     }
 
 }

--- a/webroot/js/cakephp.dataTables.js
+++ b/webroot/js/cakephp.dataTables.js
@@ -12,6 +12,7 @@ var oFilterTimerId = null;
 
 /**
  * Add search behavior to all search fields in column footer
+ * Uses parameter 'delay' (milliseconds)
  */
 function initColumnSearch()
 {

--- a/webroot/js/cakephp.dataTables.js
+++ b/webroot/js/cakephp.dataTables.js
@@ -11,16 +11,9 @@ var table = null;
 var oFilterTimerId = null;
 
 /**
- * Default filter delay to optimize performance
- * @type {number}
- */
-var delay = 600;
-
-/**
  * Add search behavior to all search fields in column footer
- *
-*/
-function initSearch ()
+ */
+function initColumnSearch()
 {
     table.api().columns().every( function () {
         var index = this.index();
@@ -28,7 +21,7 @@ function initSearch ()
             // -- set search
             table.api().column(index).search( this.value );
             window.clearTimeout(oFilterTimerId);
-            oFilterTimerId = window.setTimeout(drawTable , delay);
+            oFilterTimerId = window.setTimeout(drawTable , params.delay);
         });
     });
 };


### PR DESCRIPTION
Remove redundant default option dataSrc, make custom js code more flexible:
1. all parameters to javascript are in config array 'js', e.g.  'js.delay'
2. in 'js.calls' a list of javascript function names to call is provided
3. initSearch() is renamed to initColumnSearch()

Use cases:
1. when not using search columns initSearch() doesn't work as intended, so by passing js.calls => [] it can be disabled
2. after helper functions that define callbacks etc. may be added and parameters they need for operation as well
3. DataTablesHelper can also be used without serverside processing, e.g. when all data is loaded in initial view (no pagination)

Note: this conflicts with #9 and #11, I can also provide a pull request that is based on them.
