### PR TITLE
Add clickable behavior to table rows

### DIFF
--- a/src/View/Helper/DataTablesHelper.php
+++ b/src/View/Helper/DataTablesHelper.php
@@ -17,9 +17,6 @@ class DataTablesHelper extends Helper
     use StringTemplateTrait;
 
     protected $_defaultConfig = [
-        'ajax' => [
-            'dataSrc' => 'data'
-        ],
         'searching' => true,
         'processing' => true,
         'serverSide' => true,

--- a/src/View/Helper/DataTablesHelper.php
+++ b/src/View/Helper/DataTablesHelper.php
@@ -22,13 +22,22 @@ class DataTablesHelper extends Helper
         'serverSide' => true,
         'deferRender' => true,
         'dom' => '<<"row"<"col-sm-4"i><"col-sm-8"lp>>rt>',
-        'delay' => 600
+        'js' => [
+            'calls' => null,
+            'delay' => 600,
+        ],
     ];
 
     public function init(array $options = [])
     {
         $this->_templater = $this->templater();
         $this->config($options);
+
+        // -- default to initColumnSearch() if user didn't specify js calls array
+        if(is_null($this->config('js.calls')))
+        {
+            $this->config('js.calls', ['initColumnSearch']);
+        }
 
         // -- load i18n
         $this->config('language', [
@@ -53,7 +62,18 @@ class DataTablesHelper extends Helper
 
     public function draw($selector)
     {
-        echo sprintf('delay=%d;table=jQuery("%s").dataTable(%s);initSearch();', $this->config('delay'), $selector, json_encode($this->config()) );
+        // -- pass on parameters to javascript
+        $json = json_encode($this->config('js'));
+        $js = "params = $json;";
+
+        // -- initialize DataTables
+        $json = json_encode($this->config());
+        $js .= "table=jQuery('$selector').dataTable($json);";
+
+        // -- call javascript methods
+        $js .= implode('();', $this->config('js.calls')).'();';
+
+        echo $js;
     }
 
 }

--- a/webroot/js/cakephp.dataTables.js
+++ b/webroot/js/cakephp.dataTables.js
@@ -12,6 +12,7 @@ var oFilterTimerId = null;
 
 /**
  * Add search behavior to all search fields in column footer
+ * Uses parameter 'delay' (milliseconds)
  */
 function initColumnSearch()
 {

--- a/webroot/js/cakephp.dataTables.js
+++ b/webroot/js/cakephp.dataTables.js
@@ -11,6 +11,20 @@ var table = null;
 var oFilterTimerId = null;
 
 /**
+ * Add clickable behavior to table rows
+ * Builds upon datatables-select. As soon as a row is selected, the link fires
+ * Uses parameter rowLinkBase (e.g. controller + action link)
+ */
+function initRowLinks()
+{
+    table.api().on('select', function (e, dt, type, indexes) {
+        var rowData = table.api().rows(indexes).data();
+        var id = rowData[0].id;
+        window.location.href = params.rowLinkBase + '/' + id;
+    });
+}
+
+/**
  * Add search behavior to all search fields in column footer
  * Uses parameter 'delay' (milliseconds)
  */

--- a/webroot/js/cakephp.dataTables.js
+++ b/webroot/js/cakephp.dataTables.js
@@ -11,16 +11,9 @@ var table = null;
 var oFilterTimerId = null;
 
 /**
- * Default filter delay to optimize performance
- * @type {number}
- */
-var delay = 600;
-
-/**
  * Add search behavior to all search fields in column footer
- *
-*/
-function initSearch ()
+ */
+function initColumnSearch()
 {
     table.api().columns().every( function () {
         var index = this.index();
@@ -28,7 +21,7 @@ function initSearch ()
             // -- set search
             table.api().column(index).search( this.value );
             window.clearTimeout(oFilterTimerId);
-            oFilterTimerId = window.setTimeout(drawTable , delay);
+            oFilterTimerId = window.setTimeout(drawTable , params.delay);
         });
     });
 };


### PR DESCRIPTION
Builds upon datatables-select. As soon as a row is selected, the link fires.

Usage:

``` php
    $dt = $this->DataTables->init([
        'js' => [
            'calls' => ['initRowLinks'],
            'rowLinkBase' => $this->Url->build(['action' => 'view']),
        ],
        'select' => 'single,
         // etc.
```

Includes #12 
