### PR TITLE
Allow to specify callbacks

### DIFF
--- a/src/View/Helper/DataTablesHelper.php
+++ b/src/View/Helper/DataTablesHelper.php
@@ -71,6 +71,9 @@ class DataTablesHelper extends Helper
 
         // -- initialize DataTables
         $json = json_encode($this->config());
+        $code = 'function (args) { return $1.apply(this, arguments); }';
+        $json = preg_replace('/"callback:(.*?)"/', $code, $json);
+
         $js .= "table=jQuery('$selector').dataTable($json);";
 
         // -- call javascript methods

--- a/src/View/Helper/DataTablesHelper.php
+++ b/src/View/Helper/DataTablesHelper.php
@@ -25,13 +25,22 @@ class DataTablesHelper extends Helper
         'serverSide' => true,
         'deferRender' => true,
         'dom' => '<<"row"<"col-sm-4"i><"col-sm-8"lp>>rt>',
-        'delay' => 600
+        'js' => [
+            'calls' => null,
+            'delay' => 600,
+        ],
     ];
 
     public function init(array $options = [])
     {
         $this->_templater = $this->templater();
         $this->config($options);
+
+        // -- default to initColumnSearch() if user didn't specify js calls array
+        if(is_null($this->config('js.calls')))
+        {
+            $this->config('js.calls', ['initColumnSearch']);
+        }
 
         // -- load i18n
         $this->config('language', [
@@ -56,7 +65,18 @@ class DataTablesHelper extends Helper
 
     public function draw($selector)
     {
-        echo sprintf('delay=%d;table=jQuery("%s").dataTable(%s);initSearch();', $this->config('delay'), $selector, json_encode($this->config()) );
+        // -- pass on parameters to javascript
+        $json = json_encode($this->config('js'));
+        $js = "params = $json;";
+
+        // -- initialize DataTables
+        $json = json_encode($this->config());
+        $js .= "table=jQuery('$selector').dataTable($json);";
+
+        // -- call javascript methods
+        $js .= implode('();', $this->config('js.calls')).'();';
+
+        echo $js;
     }
 
 }

--- a/webroot/js/cakephp.dataTables.js
+++ b/webroot/js/cakephp.dataTables.js
@@ -11,16 +11,9 @@ var table = null;
 var oFilterTimerId = null;
 
 /**
- * Default filter delay to optimize performance
- * @type {number}
- */
-var delay = 600;
-
-/**
  * Add search behavior to all search fields in column footer
- *
-*/
-function initSearch ()
+ */
+function initColumnSearch()
 {
     table.api().columns().every( function () {
         var index = this.index();
@@ -28,7 +21,7 @@ function initSearch ()
             // -- set search
             table.api().column(index).search( this.value );
             window.clearTimeout(oFilterTimerId);
-            oFilterTimerId = window.setTimeout(drawTable , delay);
+            oFilterTimerId = window.setTimeout(drawTable , params.delay);
         });
     });
 };


### PR DESCRIPTION
Replaces all callback:<methodname> strings with a javascript function that calls <methodname> with its arguments.
E.g. you can specify:

``` php
        columns => [
                [
                        'name' => 'Users.color',
                        'data' => 'color',
                        'render' => 'callback:renderColor',
                ],
```

etc.

Then implement a js function:

``` javascript
    function renderColor(data, type, full, meta)
    {
        if (type === 'display') {
            return '<span style="color: '+data+';">'+data+'</span>';
        }
        return data;
    }
```

(see DataTables doc for columns.render option)

**Partially** includes #12 
