### PR TITLE
Include custom finder method in DataTables->find() options array

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ Use it simply like find:
 The array_merge is required because the component add multiple vars to view like recordsTotal, recordsFiltered, ...
 So your serialized data were added to this vars.
 
+A custom finder can be used by including 'finder' in the options array of your DataTables->find() method:
+
+    $data = $this->DataTables->find('*TABLE*', [
+        'contain' => [],
+        'finder' => '*CUSTOM FINDER NAME*'
+    ]);
+    
+By default, the 'all' finder will be used.
+
 
 ### Step 5: Template / View
 

--- a/src/Controller/Component/DataTablesComponent.php
+++ b/src/Controller/Component/DataTablesComponent.php
@@ -104,9 +104,13 @@ class DataTablesComponent extends Component
      * @param array $options
      * @return array|\Cake\ORM\Query
      */
-    public function find($tableName, $finder = 'all', array $options = [])
+    public function find($tableName, array $options = [])
     {
-
+        // -- set default option values
+        $options += ['finder' => 'all'];
+        $finder = $options['finder'];
+        unset($options['finder']);
+    
         // -- get table object
         $table = TableRegistry::get($tableName);
         $this->_tableName = $table->alias();


### PR DESCRIPTION
When $finder is set as second argument of the find function, it can
cause errors if user fails to set it and instead sets the $options array
as the second argument. This change makes it so the custom finder
method, if used, is included in the options array instead of as second
argument, improving usability in addition to following CakePHP best
practices. Also updates readme to reflect availability of this feature.
